### PR TITLE
Update for osg-htc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This repository contains the source for the OSG All Hands Meeting pages
 
 ## Other OSG documentation on Github
 
-- [OSG Council](https://opensciencegrid.github.io/council)
-- [OSG Production](https://opensciencegrid.github.io/production)
+- [OSG Council](https://osg-htc.org/council)
+- [OSG Production](https://osg-htc.org/production)
 
 ## Resources
 

--- a/docs/2019/index.md
+++ b/docs/2019/index.md
@@ -1,6 +1,6 @@
 # OSG All-Hands Meeting 2019
 
-The [Open Science Grid](https://www.opensciencegrid.org) (OSG) and [Thomas Jefferson National Accelerator
+The [Open Science Grid](https://osg-htc.org) (OSG) and [Thomas Jefferson National Accelerator
 Facility](https://www.jlab.org) (JLab) invite you to attend:
 
 <div style="border: 1px solid #3F51B5; color: #20295A; background-color: #E7E9F6; padding: 1ex; font-size: 115%; font-weight: bold;">

--- a/docs/2022/logistics.md
+++ b/docs/2022/logistics.md
@@ -26,7 +26,7 @@ Staff will watch for questions in the Everyone chat.
 
 We want all participants to be able to enjoy the meeting equally,
 so we expect everyone to follow the
-[OSG Code of Conduct](https://opensciencegrid.org/management/conduct/).
+[OSG Code of Conduct](https://osg-htc.org/management/conduct/).
 
 ## Information for Presenters
 


### PR DESCRIPTION
All opensciencegrid.org/** websites have been moved so this is the final clean up of existing pointers to the previous locations.

Another pass will be done in the future to clean up **.opensciencegrid.org subdomains when they are transferred.